### PR TITLE
IO.readline has been deprecated, IO.read(device, :line) works

### DIFF
--- a/code/ch06-05/college.ex
+++ b/code/ch06-05/college.ex
@@ -23,7 +23,7 @@ defmodule College do
   # the room on that line. Recursively read through end of file.
   
   defp process_line(device, room_list) do
-    data = IO.readline(device)
+    data = IO.read(device, :read)
     case data do
       :eof ->
         File.close(device)


### PR DESCRIPTION
Tested on Interactive Elixir (0.11.2)
