### PR TITLE
IO.readline has been deprecated, IO.read(device, :line) works

### DIFF
--- a/code/ch10-01/phone_ets.ex
+++ b/code/ch10-01/phone_ets.ex
@@ -39,7 +39,7 @@ defmodule PhoneEts do
   @spec add_rows(IO.device) :: atom
   
   defp add_rows(input_file) do
-    data = IO.readline(input_file)
+    data = IO.read(input_file, :line)
     cond do
       data != :eof ->
         [number, sdate, stime, edate, etime] =


### PR DESCRIPTION
Tested on Interactive Elixir (0.11.2)
