### PR TITLE
ch07-03 accumulate across countries

### DIFF
--- a/code/ch07-03/geography.ex
+++ b/code/ch07-03/geography.ex
@@ -47,7 +47,7 @@ defmodule Geography do
 
   defp total_population([head|tail], language, total) do
     if (head.language == language) do
-      total_population(tail, language, subtotal(head.cities, 0))
+      total_population(tail, language, total + subtotal(head.cities, 0))
     else
       total_population(tail, language, total)
     end


### PR DESCRIPTION
Max: Avoid loosing previous country population while stepping to another country.

Hi there, please merge this fix for the Geography module.

With fix:
```
iex(112)> Geography.total_population Geography.make_geo_list("geography2.csv"), "Spanish" 
13455613
```
Without fix:
```
iex(113)> c "geography2.ex"                                                              geography2.ex:1: warning: redefining module City
geography2.ex:5: warning: redefining module Country
geography2.ex:9: warning: redefining module Geography
[Geography, Country, City]
iex(114)> Geography.total_population Geography.make_geo_list("geography2.csv"), "Spanish" 
4877481
```
Manual check:
```
iex(116)> 3255944 + 1621537 + 7737002 + 841130
13455613
```