### PR TITLE
12.1 CompileError (weather.ex). Erlangs atom_to_binary() removed

### DIFF
--- a/code/ch12-01/weather.ex
+++ b/code/ch12-01/weather.ex
@@ -78,7 +78,7 @@ defmodule Weather do
   
   defp get_content(element_name, xml) do
     {_, pattern} = Regex.compile(
-    "<#{element_name}>([^<]+)</#{atom_to_binary(element_name)}>")
+    "<#{element_name}>([^<]+)</#{element_name}>")
     result = Regex.run(pattern, xml)
     case result do
       [_all, match] -> {element_name, match}

--- a/code/ch12-02/weather.ex
+++ b/code/ch12-02/weather.ex
@@ -96,7 +96,7 @@ defmodule Weather do
   
   defp get_content(element_name, xml) do
     {_, pattern} = Regex.compile(
-    "<#{element_name}>([^<]+)</#{atom_to_binary(element_name)}>")
+    "<#{element_name}>([^<]+)</#{element_name}>")
     result = Regex.run(pattern, xml)
     case result do
       [_all, match] -> {element_name, match}

--- a/code/ch12-03/weather.ex
+++ b/code/ch12-03/weather.ex
@@ -115,7 +115,7 @@ defmodule Weather do
   
   defp get_content(element_name, xml) do
     {_, pattern} = Regex.compile(
-    "<#{element_name}>([^<]+)</#{atom_to_binary(element_name)}>")
+    "<#{element_name}>([^<]+)</#{element_name}>")
     result = Regex.run(pattern, xml)
     case result do
       [_all, match] -> {element_name, match}


### PR DESCRIPTION
Trace:

```bash

iex(4)> c("weather.ex")

== Compilation error on file weather.ex ==
** (CompileError) weather.ex:81: function atom_to_binary/1 undefined
    (stdlib) lists.erl:1337: :lists.foreach/2
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6

** (exit) shutdown: 1
    (elixir) lib/kernel/parallel_compiler.ex:199: Kernel.ParallelCompiler.handle_failure/5
    (elixir) lib/kernel/parallel_compiler.ex:182: Kernel.ParallelCompiler.wait_for_messages/8
    (elixir) lib/kernel/parallel_compiler.ex:55: Kernel.ParallelCompiler.spawn_compilers/3
       (iex) lib/iex/helpers.ex:94: IEx.Helpers.c/2

```

Etude plays as described after this fix.
