### PR TITLE
Fixed Typo that was pointing to the wrong link

### DIFF
--- a/ch09-processes.asciidoc
+++ b/ch09-processes.asciidoc
@@ -119,7 +119,7 @@ she hasn't picked up yet.
 
 Hints for Testing
 ^^^^^^^^^^^^^^^^^
-Modify the +cards+ module that you wrote in <<CH07-ET06,Étude 7-6>>
+Modify the +cards+ module that you wrote in <<CH08-ET05,Étude 8-5>>
 to generate a small deck with, say, only
 four cards in two suits. If you try to play with a full deck, the game could
 go on for a very, very long time.


### PR DESCRIPTION
In **Hints for Testing** In Chapter 09, The cards module we wrote was in _Etude 8-5_ and not in _Etude 7-6_, which is the typo that was fixed
