### PR TITLE
Update to String.to_integer and String.to_float

### DIFF
--- a/appendix-a.asciidoc
+++ b/appendix-a.asciidoc
@@ -186,7 +186,7 @@ The +geom.ex+ file is the same as in <<CH05-ET01,Étude 5-1>>.
 ==== +ask_area.ex+
 // [source,elixir]
 ----
-include::code/ch05-01/ask_area.ex[]
+include::code/ch05-02/ask_area.ex[]
 ----
 
 [[SOLUTION05-ET03]]

--- a/ch05-strings.asciidoc
+++ b/ch05-strings.asciidoc
@@ -76,7 +76,7 @@ program work.
   This involves the following steps:
 
   * Use +String.strip/1+ to get rid of the trailing newline character
-  * Use +string_to_integer/1+ to convert the string to a number.
+  * Use +String.to_integer/1+ to convert the string to a number.
 
 +
 When you write the +-spec+ for this function (you _have_ been
@@ -123,7 +123,7 @@ Enter width > 3.5
     /bin/elixir/lib/iex/lib/iex/server.ex:19: IEx.Server.do_loop/1
 ----
 
-In this étude, you will use _regular expressions_ to make sure that input is numeric and to distinguish integers from floating point numbers. You need to do this because +binary_to_float/1+ will not accept a string like +"1812"+ as an argument. If you aren't familiar with regular expressions, there is a short summary in <<APPENDIXB>>.
+In this étude, you will use _regular expressions_ to make sure that input is numeric and to distinguish integers from floating point numbers. You need to do this because +String.to_float/1+ will not accept a string like +"1812"+ as an argument. If you aren't familiar with regular expressions, there is a short summary in <<APPENDIXB>>.
 
 The function you will use is the +Regex.match?/2+. It takes a regular expression pattern as its first argument and a string as its second argument. The function returns +true+ if the pattern matches the string, +false+ otherwise. Here are some examples in IEx.
 

--- a/code/ch05-01/ask_area.ex
+++ b/code/ch05-01/ask_area.ex
@@ -54,7 +54,7 @@ defmodule AskArea do
   
   def get_number(prompt) do
     input = IO.gets("Enter #{prompt} > ")
-    string_to_integer(String.strip(input))
+    String.to_integer(String.strip(input))
   end
   
   @doc """

--- a/code/ch05-02/ask_area.ex
+++ b/code/ch05-02/ask_area.ex
@@ -57,9 +57,9 @@ defmodule AskArea do
     input_str = String.strip(input)
     cond do
       Regex.match?(~r/^[+-]?\d+$/, input_str) ->
-        binary_to_integer(input_str)
+        String.to_integer(input_str)
       Regex.match?(~r/^[+-]?\d+\.\d+([eE][+-]?\d+)?$/, input_str) ->
-        binary_to_float(input_str)
+        String.to_float(input_str)
       true -> :error
     end
   end

--- a/code/ch05-03/dates.ex
+++ b/code/ch05-03/dates.ex
@@ -15,7 +15,7 @@ defmodule Dates do
 
   def date_parts(date_str) do
     [y_str, m_str, d_str] = String.split(date_str, ~r/-/)
-    [binary_to_integer(y_str), binary_to_integer(m_str),
-      binary_to_integer(d_str)]
+    [String.to_integer(y_str), String.to_integer(m_str),
+      String.to_integer(d_str)]
   end
 end


### PR DESCRIPTION
Hi,

`binary_to_integer` and `binary_to_float` are undefined on Elixir v1.0.5. 

I found that `String.to_integer` and `String.to_float` which respectively call [`:erlang.binary_to_integer`](https://github.com/elixir-lang/elixir/blob/v1.0.5/lib/elixir/lib/string.ex#L1412) and `:erlang.binary_to_float` under the hood do the work now.

Also fixed the wrong file inclusion in appendix-a.asciidoc.

Hope this helps!