### PR TITLE
Changed binary_to_(integer/float) into String.to_(integer/float).

### DIFF
--- a/ch05-strings.asciidoc
+++ b/ch05-strings.asciidoc
@@ -123,7 +123,7 @@ Enter width > 3.5
     /bin/elixir/lib/iex/lib/iex/server.ex:19: IEx.Server.do_loop/1
 ----
 
-In this étude, you will use _regular expressions_ to make sure that input is numeric and to distinguish integers from floating point numbers. You need to do this because +binary_to_float/1+ will not accept a string like +"1812"+ as an argument. If you aren't familiar with regular expressions, there is a short summary in <<APPENDIXB>>.
+In this étude, you will use _regular expressions_ to make sure that input is numeric and to distinguish integers from floating point numbers. You need to do this because +String.to_float/1+ will not accept a string like +"1812"+ as an argument. If you aren't familiar with regular expressions, there is a short summary in <<APPENDIXB>>.
 
 The function you will use is the +Regex.match?/2+. It takes a regular expression pattern as its first argument and a string as its second argument. The function returns +true+ if the pattern matches the string, +false+ otherwise. Here are some examples in IEx.
 

--- a/code/ch05-02/ask_area.ex
+++ b/code/ch05-02/ask_area.ex
@@ -57,9 +57,9 @@ defmodule AskArea do
     input_str = String.strip(input)
     cond do
       Regex.match?(~r/^[+-]?\d+$/, input_str) ->
-        binary_to_integer(input_str)
+        String.to_integer(input_str)
       Regex.match?(~r/^[+-]?\d+\.\d+([eE][+-]?\d+)?$/, input_str) ->
-        binary_to_float(input_str)
+        String.to_float(input_str)
       true -> :error
     end
   end

--- a/code/ch05-03/dates.ex
+++ b/code/ch05-03/dates.ex
@@ -15,7 +15,7 @@ defmodule Dates do
 
   def date_parts(date_str) do
     [y_str, m_str, d_str] = String.split(date_str, ~r/-/)
-    [binary_to_integer(y_str), binary_to_integer(m_str),
-      binary_to_integer(d_str)]
+    [String.to_integer(y_str), String.to_integer(m_str),
+      String.to_integer(d_str)]
   end
 end

--- a/code/ch06-02/dates.ex
+++ b/code/ch06-02/dates.ex
@@ -47,7 +47,7 @@ defmodule Dates do
 
   def date_parts(date_str) do
     [y_str, m_str, d_str] = String.split(date_str, ~r/-/)
-    [binary_to_integer(y_str), binary_to_integer(m_str),
-      binary_to_integer(d_str)]
+    [String.to_integer(y_str), String.to_integer(m_str),
+      String.to_integer(d_str)]
   end
 end

--- a/code/ch06-02b/dates.ex
+++ b/code/ch06-02b/dates.ex
@@ -47,7 +47,7 @@ defmodule Dates do
 
   def date_parts(date_str) do
     [y_str, m_str, d_str] = String.split(date_str, ~r/-/)
-    [binary_to_integer(y_str), binary_to_integer(m_str),
-      binary_to_integer(d_str)]
+    [String.to_integer(y_str), String.to_integer(m_str),
+      String.to_integer(d_str)]
   end
 end

--- a/code/ch08-04/dates.ex
+++ b/code/ch08-04/dates.ex
@@ -44,7 +44,7 @@ defmodule Dates do
 
   def date_parts(date_str) do
     [y_str, m_str, d_str] = String.split(date_str, ~r/-/)
-    [binary_to_integer(y_str), binary_to_integer(m_str),
-      binary_to_integer(d_str)]
+    [String.to_integer(y_str), String.to_integer(m_str),
+      String.to_integer(d_str)]
   end
 end

--- a/code/ch10-02/bank.ex
+++ b/code/ch10-02/bank.ex
@@ -81,9 +81,9 @@ defmodule Bank do
     input_str = String.strip(input)
     cond do
       Regex.match?(~r/^[+-]?\d+$/, input_str) ->
-        binary_to_integer(input_str)
+        String.to_integer(input_str)
       Regex.match?(~r/^[+-]?\d+\.\d+([eE][+-]?\d+)?$/, input_str) ->
-        binary_to_float(input_str)
+        String.to_float(input_str)
       true -> :error
     end
   end     

--- a/code/ch11-01/phone_ets.ex
+++ b/code/ch11-01/phone_ets.ex
@@ -70,7 +70,7 @@ defmodule PhoneEts do
   
   defp gregorianize(str, delimiter) do
     list_to_tuple(for item <- String.split(str, delimiter), do:
-      binary_to_integer(item))
+      String.to_integer(item))
   end   
   
   @doc """


### PR DESCRIPTION
It was refactored as you can see elixir-lang/elixir#1044

Now it can be used either as `:erlang.binary_to_integer/1` or as `String.to_integer/1` which should be the Elixir way, according to this refactoring :smile: 

Thanks for this great book! :+1: 
