### PR TITLE
Shuffle player hand on pickup

### DIFF
--- a/code/ch09-01/player.ex
+++ b/code/ch09-01/player.ex
@@ -15,7 +15,7 @@ defmodule Player do
         send(dealer, {:take, to_send, self()})
         play(to_keep)
       {:pick_up, cards, dealer} ->
-        new_hand = hand ++ cards
+        new_hand = Cards.shuffle(hand ++ cards)
         IO.puts("Player #{inspect(self)} has #{inspect(new_hand)}")
         send(dealer, {:got_cards, self()})
         play(new_hand)


### PR DESCRIPTION
With a full deck the runtime of the game can be enormous.
Shuffling the player's hand is pretty effective at breaking gameplay cycles.
This changes the expected runtime from "unbearable" with 4 suits to "reasonable" with even 15 suits.

This also would allow for a paragraph on flow control and ~~is an interesting type of deadlock~~ preventing deadlock.