### PR TITLE
Change String.strip/1 to String.trim/1

### DIFF
--- a/ch05-strings.asciidoc
+++ b/ch05-strings.asciidoc
@@ -75,7 +75,7 @@ program work.
   +"Enter _prompt_ > "+ and returns the number that was input.
   This involves the following steps:
 
-  * Use +String.strip/1+ to get rid of the trailing newline character
+  * Use +String.trim/1+ to get rid of the trailing newline character
   * Use +string_to_integer/1+ to convert the string to a number.
 
 +


### PR DESCRIPTION
The elixir source code has String.strip/1 listed as deprecated and to be removed by v2.0.