### PR TITLE
Fix broken link in Étude 7-3

### DIFF
--- a/appendix-a.asciidoc
+++ b/appendix-a.asciidoc
@@ -316,7 +316,7 @@ include::code/ch07-03/geography.ex[]
 Here is a suggested solution for
 <<CH07-ET04,Étude 7-4>>. The code shown here is the code
 required to implement the additional protocols; the remaining
-code is the same as in [[SOLUTION07-ET03]]
+code is the same as in <<CH07-ET03,Étude 7-3>>.
 
 ==== +city.ex+
 // [source,elixir]


### PR DESCRIPTION
In the **Étude 7-3** (http://chimera.labs.oreilly.com/books/1234000001642/ch07.html#CH07-ET03), the *See a suggested solution in Appendix A* sentence doesn't link to the correct page because the expected id doesn't exist.

This is due to a duplicated reference `[[SOLUTION07-ET03]]` (in the *appendix-a.asciidoc* file) converted into 2 different ids : **SOLUTION07-ET03_id1** and **SOLUTION07-ET03_id2** instead of a unique **SOLUTION07-ET03**.