### PR TITLE
Update deprecated code

### DIFF
--- a/code/ch08-06/cards.ex
+++ b/code/ch08-06/cards.ex
@@ -13,7 +13,7 @@ defmodule Cards do
   @spec shuffle(list) :: list
   
   def shuffle(list) do
-    :random.seed(:erlang.now())
+    :rand.seed(:exs1024, {123, 123534, 345345})
     shuffle(list, [])
   end
   
@@ -42,7 +42,7 @@ defmodule Cards do
 
   def shuffle(list, acc) do
     {leading, [h | t]} =
-      Enum.split(list, :random.uniform(Enum.count(list)) - 1)
+      Enum.split(list, :rand.uniform(Enum.count(list)) - 1)
       shuffle(leading ++ t, [h | acc])
   end
 


### PR DESCRIPTION
* erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
* random:seed/1: the 'random' module is deprecated; use the 'rand' module instead
* random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead